### PR TITLE
Creating an Auto Scaling Group

### DIFF
--- a/scripts/module_03/create-auto-scaling.js
+++ b/scripts/module_03/create-auto-scaling.js
@@ -1,7 +1,7 @@
 // Imports
 const AWS = require('aws-sdk')
 
-AWS.config.update({ region: '/* TODO: add your region */' })
+AWS.config.update({ region: 'us-east-1' })
 
 // Declare local variables
 const autoScaling = new AWS.AutoScaling()
@@ -15,7 +15,27 @@ createAutoScalingGroup(asgName, lcName)
 .then((data) => console.log(data))
 
 function createAutoScalingGroup (asgName, lcName) {
-  // TODO: Create an auto scaling group
+  // Create an auto scaling group
+  const params = {
+    AutoScalingGroupName: asgName,
+    AvailabilityZones: [
+      'us-east-1a',
+      'us-east-1b'
+    ],
+    TargetGroupARNs: [
+      tgArn
+    ],
+    LaunchConfigurationName: lcName,
+    MaxSize: 2,
+    MinSize: 1
+  }
+
+  return new Promise((resolve, reject) => {
+    autoScaling.createAutoScalingGroup(params, (err, data) => {
+      if (err) reject(err)
+      else resolve(data)
+    })
+  })
 }
 
 function createASGPolicy (asgName, policyName) {


### PR DESCRIPTION

Creating an Auto Scaling Group
--
Auto scaling groups are responsible for creating and removing EC2 instances
from a group according to configured rules.
They use a launch configuration when creating the instance and they can be attached to a target group. So each instance can be used with a load balancer.

