### PR TITLE
Configuring Auto Scaling Policies

### DIFF
--- a/scripts/module_03/create-auto-scaling.js
+++ b/scripts/module_03/create-auto-scaling.js
@@ -39,5 +39,24 @@ function createAutoScalingGroup (asgName, lcName) {
 }
 
 function createASGPolicy (asgName, policyName) {
-  // TODO: Create an auto scaling group policy
+  // Create an auto scaling group policy
+  const params = {
+    AdjustmentType: 'ChangeInCapacity',
+    AutoScalingGroupName: asgName,
+    PolicyName: policyName,
+    PolicyType: 'TargetTrackingScaling',
+    TargetTrackingConfiguration: {
+      TargetValue: 5,
+      PredefinedMetricSpecification: {
+        PredefinedMetricType: 'ASGAverageCPUUtilization'
+      }
+    }
+  }
+
+  return new Promise((resolve, reject) => {
+    autoScaling.putScalingPolicy(params, (err, data) => {
+      if (err) reject(err)
+      else resolve(data)
+    })
+  })
 }


### PR DESCRIPTION

Configuring Auto Scaling Polices
--
An Auto Scaling policy defines when an Auto Scaling group should scale up or down.
There are a few different types of Auto Scaling Polices,
Simple Scaling Policy
Simple scaling polices are the original way that Auto Scaling Groups worked.
This uses a CloudWatch alarm to monitor certain attributes and then perform an action once the alarm occurs.
Only one action can be configured per alarm. Therefore, if you want true elasticity you need a policy for scaling up and a policy for scaling down.
Monitor attributes and perform action
One action per alarm
Scaling up and down requires two polices
 
Step Scaling Policy
Step scaling policies were added as a way to define multiple actions when a single alarm fires.
This allows you to modify the behavior of a policy based on the severity of the alarm that's being fired.
The policy will keep scaling even after it's been initiated which differs from simple scaling polices.
Define multiple actions per alarm
Continuesly perform actions.
 
Target Tracking Scaling Policy
The newest scaling policy is target tracking polices, and it's what we'll use.
Target tracking polices allow you to define a target for a metric attribute,
and the policy will scale up or down to stay below that limit. It's the easiest policy, sort of a set-and-forget-type operation
and it is the suggested policy type to use now with Auto Scaling groups.
Define metric target
Auto Scaling up and down to achieve target

