### PR TITLE
Reusing EBS Volumes with EC2

### DIFF
--- a/scripts/module_04/create-ec2-instance.js
+++ b/scripts/module_04/create-ec2-instance.js
@@ -1,13 +1,13 @@
 // Imports
 const AWS = require('aws-sdk')
 
-AWS.config.update({ region: '/* TODO: Add your regions */' })
+AWS.config.update({ region: 'us-east-1' })
 
 // Declare local variables
 const ec2 = new AWS.EC2()
 const sgName = 'hamster_sg'
 const keyName = 'hamster_key'
-const instanceId = '/* TODO: Add the instance Id to stop */'
+const instanceId = 'i-0094sampleidnumber'
 
 stopInstance(instanceId)
 .then(() => createInstance(sgName, keyName))
@@ -15,13 +15,13 @@ stopInstance(instanceId)
 
 function createInstance (sgName, keyName) {
   const params = {
-    ImageId: '/* TODO: Add ami id for aws linux */',
+    ImageId: 'ami-00068samplenumber',
     InstanceType: 't2.micro',
     KeyName: keyName,
     MaxCount: 1,
     MinCount: 1,
     Placement: {
-      AvailabilityZone: '/* TODO: Add the az from the instance that is stopping */'
+      AvailabilityZone: 'us-east-1b'
     },
     SecurityGroups: [
       sgName

--- a/scripts/module_04/reuse-ebs-volume.js
+++ b/scripts/module_04/reuse-ebs-volume.js
@@ -1,28 +1,44 @@
 // Imports
 const AWS = require('aws-sdk')
 
-AWS.config.update({ region: '/* TODO: Add your region */' })
+AWS.config.update({ region: 'us-east-1' })
 
 // Declare local variables
 const ec2 = new AWS.EC2()
-const volumeId = '/* TODO: Add the volume to detach/attach */'
-const instanceId = '/* TODO: Add the instance to attach to */'
+const volumeId = '/* TODO: Add the volume to detach/attach vol-obf3abcsample */'
+const instanceId = '/* TODO: Add the instance to attach to i-049...sample*/'
 
 detachVolume(volumeId)
 .then(() => attachVolume(instanceId, volumeId))
 
 function detachVolume (volumeId) {
-  // TODO: Configure detachVolume params
+  // Configure detachVolume params
+  const params = {
+    VolumeId: volumeId
+  }
 
   return new Promise((resolve, reject) => {
-    // TODO: Detach the volume
+    // Detach the volume
+    ec2.detachVolume(params, (err, data) => {
+      if (err) reject(err)
+      else resolve(data)
+    })
   })
 }
 
 function attachVolume (instanceId, volumeId) {
-  // TODO: Configure attachVolume params
+  // Configure attachVolume params
+  const params = {
+    InstanceId: instanceId,
+    VolumeId: volumeId,
+    Device: '/dev/sdf'
+  }
 
   return new Promise((resolve, reject) => {
-    // TODO: Attach the volume
+    // Attach the volume
+    ec2.attachVolume(params, (err, data) => {
+      if (err) reject(err)
+      else resolve(data)
+    })
   })
 }


### PR DESCRIPTION

Reusing EBS Volumes with EC2 (demo)
--
There are a lot of different things you can do with EBS volumes like creating snapshots,
creating new EBS volumes from snapshots, and attaching multiple volumes & etc.
In this demo, we're going to detach an EBS volume from one instance and attach it to another.
 
Quick Note:
When to Stop an EC2 Instance
Why are we stopping the instance? Well, to detach a root volume from an instance the instance must be stopped.
If it has multiple volumes and we were detaching a non-root volume, we could detach it while it was running.
 
EBS volumes with product codes can only be attached to stopped instances.

