### PR TITLE
creating dynamo table

### DIFF
--- a/scripts/module_05/create-dynamo-table.js
+++ b/scripts/module_05/create-dynamo-table.js
@@ -1,19 +1,43 @@
 // Imports
 const AWS = require('aws-sdk')
 
-AWS.config.update({ region: '/* TODO: Add your region */' })
+AWS.config.update({ region: '' })
 
 // Declare local variables
-// TODO: Declare dynamoDB object
+// Declare dynamoDB object
+const dynamo = new AWS.DynamoDB()
 
 createTable('hamsters')
 .then(() => createTable('races'))
 .then(data => console.log(data))
 
 function createTable (tableName) {
-  // TODO: Declare params for createTable
+  // Declare params for createTable
+  const params = {
+    TableName : tableName,
+    AttributeDefinitions: [
+      {
+        AttributeName: 'id',
+        AttributeType: 'N'
+      }
+    ],
+    KeySchema: [
+      {
+        AttributeName: 'id',
+        KeyType: 'HASH'
+      }
+    ],
+    ProvisionedThroughput: {
+      ReadCapacityUnits: 5,
+      WriteCapacityUnits: 5
+    }
+  }
 
   return new Promise((resolve, reject) => {
-    // TODO: Call createTable function
+    // Call createTable function
+    dynamo.createTable(params, (err, data) => {
+      if (err) reject(err)
+      else resolve(data)
+    })
   })
 }


### PR DESCRIPTION

How DynamoDB Provisioned Throughput Works
--
DynamoDB Throughput Capacity
The number of records that can be read or written per second. 4KB per unit for, 1KB per unit for writing.
DynamoDB Burst Capacity
Used when throughput capacity is exceeded. No guarantees given from AWS of burst capacity availability.
DynamoDB Read Types
Eventual consistency : May not have recent changes
Strong consistency : Guarantees newest changes
There's no consistency discount for writing.

