### PR TITLE
From mac

### DIFF
--- a/scripts/module_06/create-route53-hostedzone.js
+++ b/scripts/module_06/create-route53-hostedzone.js
@@ -1,19 +1,28 @@
 // Imports
 const AWS = require('aws-sdk')
 
-AWS.config.update({ region: '/* TODO: Add your region */' })
+AWS.config.update({ region: 'us-west-2' })
 
 // Declare local variables
-// TODO: Create route53 object
+// Create route53 object
+const route53 =  new AWS.Route53()
 const hzName = 'hbfl.online'
 
 createHostedZone(hzName)
 .then(data => console.log(data))
 
 function createHostedZone (hzName) {
-  // TODO: Create params const
+  // Create params const
+  const params = {
+    Name: hzName,
+    CallerReference: `${Date.now()}`
+  }
 
   return new Promise((resolve, reject) => {
-    // TODO: Create hostedzone with route53
+    // Create hostedzone with route53
+    route53.createHostedZone(params, (err, data) => {
+      if (err) reject(err)
+      else resolve(data)
+    })
   })
 }

--- a/scripts/module_06/create-route53-hostedzone.js
+++ b/scripts/module_06/create-route53-hostedzone.js
@@ -1,9 +1,6 @@
-// Imports
 const AWS = require('aws-sdk')
-
 AWS.config.update({ region: 'us-west-2' })
 
-// Declare local variables
 // Create route53 object
 const route53 =  new AWS.Route53()
 const hzName = 'hbfl.online'

--- a/scripts/module_06/create-route53-recordset.js
+++ b/scripts/module_06/create-route53-recordset.js
@@ -1,21 +1,42 @@
-// Imports
 const AWS = require('aws-sdk')
-
-AWS.config.update({ region: '/* TODO: Add your region */' })
+AWS.config.update({ region: 'us-west-1' })
 
 // Declare local variables
 const route53 = new AWS.Route53()
-const hzId = '/* TODO: Add your hostedzone id */'
+const hzId = '/hostedzone/Z@8LUDOK29M3AN-sample'
 
 createRecordSet(hzId)
 .then(data => console.log(data))
 
 function createRecordSet (hzId) {
-  // TODO: Create params const
+  // Create params const
+  const params = {
+    HostedZoneId: hzId,
+    ChangeBatch: {
+      Changes: [
+        { 
+          Action: 'CREATE',
+          ResourceRecordSet: {
+            Name: 'hbfl.online',
+            Type: 'A',
+            AliasTarget: {
+              DNSName: 'hamsterELB-1470466383.us-west-1.elb.amazonaws.com',
+              EvaluateTargetHealth: false,
+              HostedZonId: 'Z18D5FSROUN65G'
+            }
+          }
+        }
+      ]
+    }
+  }
   // Link to ELB Regions:
   // https://docs.aws.amazon.com/general/latest/gr/elb.html
 
   return new Promise((resolve, reject) => {
-    // TODO: Create record set
+    // Create record set
+    route53.changeResourceRecordsets(params, (err, data) => {
+      if (err) reject(err)
+      else resolve(data)
+    })
   })
 }


### PR DESCRIPTION

Creating a Hosted Zone in Route 53
--
Route 53 has two key concepts to know when setting it up to support a domain name.

Route 53 Hosted Zone (demo)
Resource that maps to a domain name through which you can configure subdomains and other routing rules.
Route 53 Record Set (demo)
DNS rules that send traffic from a source to a AWS resource.

