### PR TITLE
Deploying an API in API Gateway

### DIFF
--- a/scripts/module_06/create-api-gateway.js
+++ b/scripts/module_06/create-api-gateway.js
@@ -60,6 +60,12 @@ function createResource (parentResourceId, resourcePath, api) {
     restApiId: api.id
   }
 
+  if (path) {
+    params.requestParameters = {
+      [`method.request.path.${path}`]: true
+    }
+  }
+
   return new Promise((resolve, reject) => {
     // Create the resource and return the resource id
     apiG.createResource(params, (err, data) => {
@@ -96,6 +102,13 @@ function createMethodIntegration (resourceId, method, api, path) {
     uri: 'http://hamsterELB-1470466383.us-east-1.elb.amazonaws.com'
   }
 
+  if (path) {
+    params.uri += `/{${path}}`
+    params.requestParameters = {
+      [`integration.request.path.${path}`]: `method.request.path.${path}`
+    }
+  }
+
   return new Promise((resolve, reject) => {
     // Put the integration and return the resourceId argument
     apiG.putIntegration(params, (err) => {
@@ -104,3 +117,4 @@ function createMethodIntegration (resourceId, method, api, path) {
     })
   })
 }
+

--- a/scripts/module_06/deploy-api-gateway.js
+++ b/scripts/module_06/deploy-api-gateway.js
@@ -1,19 +1,25 @@
 // Imports
 const AWS = require('aws-sdk')
 
-AWS.config.update({ region: '/* TODO: Add your region */' })
+AWS.config.update({ region: 'us-west-1' })
 
 // Declare local variables
 const apiG = new AWS.APIGateway()
-const apiId = '/* TODO: Add api id */'
+const apiId = 'qgv7dtxjvj'
 
 createDeployment(apiId, 'prod')
 .then(data => console.log(data))
 
 function createDeployment (apiId, stageName) {
-  // TODO: Create params const
+  const params = {
+    restApiId: apiId,
+    stageName: stageName
+  }
 
   return new Promise((resolve, reject) => {
-    // TODO: Create deployment
+    apiG.createDeployment(params, (err, data) => {
+      if (err) reject(err)
+      else resolve(data)
+    })
   })
 }


### PR DESCRIPTION

Deploying an API in API Gateway (demo)
--
There are two key concepts, stages, and deployments.
API Gateway lets you create stages for your APIs.
Think of stages like development, integration, stagin and production.
You can deploy your API to different stages in order to have a healthy
development lifecycle. Each time you deploy to a stage ad deployment is
created These are saved in the history each stage, so you can move
between them easily especially in cases where you might need to roll back.
To make our REST API accessible we need to deploy it.

