### PR TITLE
Creating a CloudFront Distribution

### DIFF
--- a/handlers/template/index.html
+++ b/handlers/template/index.html
@@ -2,12 +2,12 @@
 <html>
   <head>
     <title>Hamster Ball Fantasy League</title>
-    <link rel="stylesheet" href="https://s3.amazonaws.com/hamster-bucket-david/stylesheet.css" />
+    <link rel="stylesheet" href="https://dr9rb3ildwj8z.cloudfront.net/stylesheet.css" />
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,300i,500,500i,900i" rel="stylesheet" />
   </head>
   <body>
     <div id="app"></div>
     <script>window.__PRELOADED_STATE__ = $$state</script>
-    <script src="https://s3.amazonaws.com/hamster-bucket-david/application.min.js"></script>
+    <script src="https://dr9rb3ildwj8z.cloudfront.net/application.min.js"></script>
   </body>
 </html>

--- a/scripts/module_07/cloudfront-parameters.js
+++ b/scripts/module_07/cloudfront-parameters.js
@@ -1,11 +1,46 @@
 function origins (bucketName) {
   return {
-    // TODO: Add properties for Origins
+    Quantity: 1,
+    Items: [
+      {
+        DomainName: `${bucketName}.s3.amazonaws.com`,
+        Id: `${bucketName}_origin`,
+        S3OriginConfig: {
+          OriginAccessIdentity: ''
+        }
+      }
+    ]
   }
 }
 function defaultCacheBehavior (bucketName) {
   return {
-    // TODO: Add properties for DefaultCacheBehavior
+    ForwardedValues: {
+      Cookies: {
+        Forward: 'none'
+      },
+      QueryString: false
+    },
+    MinTTL: 0,
+    TargetOriginId: `${bucketName}_origin`,
+    TrustedSigners: {
+      Quantity: 0,
+      Enabled: false
+    },
+    ViewerProtocolPolicy: 'redirect-to-https',
+    AllowedMethods: {
+      Quantity: 2,
+      Items: [
+        'GET',
+        'HEAD'
+      ],
+      CachedMethods: {
+        Quantity: 2,
+        Items: [
+          'GET',
+          'HEAD'
+        ]
+      }
+    }
   }
 }
 

--- a/scripts/module_07/create-cloudfront-distribution.js
+++ b/scripts/module_07/create-cloudfront-distribution.js
@@ -2,18 +2,31 @@
 const AWS = require('aws-sdk')
 const cfParams = require('./cloudfront-parameters')
 
-AWS.config.update({ region: '/* TODO: Add your region */' })
+AWS.config.update({ region: 'us-west-2' })
+// Create CloudFront SDK Object
+const cf = new AWS.CloudFront()
 
-// Declare local variables
-// TODO: Create CloudFront SDK Object
-
-createDistribution('/* TODO: Add your bucket name */')
+createDistribution('hamster-bucket-david') // /* Add your bucket name */
 .then(data => console.log(data))
 
 function createDistribution (bucketName) {
-  // TODO: Create params const object
+  const params = {
+    DistributionConfig: {
+      CallerReference: `${Date.now()}`,
+      Comment: 'HBFL Distribution',
+      DefaultCacheBehavior: cfParams.defaultCacheBehavior(bucketName),
+      Origins: cfParams.origins(bucketName),
+      HttpVersion: 'http2',
+      PriceClass: 'PriceClass_100',
+      IsIPV6Enabled: true,
+      Enabled: true
+    }
+  }
 
   return new Promise((resolve, reject) => {
-    // TODO: Call createDistribution
+    cf.createDistribution(params, (err, data) => {
+      if (err) reject(err)
+      else resolve(data)
+    })
   })
 }

--- a/util/assets.js
+++ b/util/assets.js
@@ -1,4 +1,4 @@
-const base = 'https://s3.amazonaws.com/hamster-bucket-david/'
+const base = 'https://dr9rb3ildwj8z.cloudfront.net'
 module.exports = {
   hamster1: base + '/images/hamster-1-final.png',
   hamster2: base + '/images/hamster-2-final.png',


### PR DESCRIPTION

Understanding CloudFront Invalidations
--
Maximum TTL
The maximum amount of time an object will stay in CludFront cache before a new copy is retrieved from the origin. The higher, the better.Default is one year.
 
There are two real solutions to make the most out of a high time-to-live value.
The first is to invalidate content when you've got a new version available.
This can be done by sending an invalidation to CloudFront.
CloudFront Invalidations
Replaces a designated object with a fresh copy from the origin
Can contain multiple files or directories
3000 object invalidation hard limit
1000 free invalidations/month
Can take minutes to process
 
The second solution which would work better for many applications using CloudFront
is to treat your assets as immutable and never change them.
Immutable Objects in CloudFront
Can be cached for maximum TTL and no invalidations needed
Each object has unique name (eg. add hash)
CloudFront retrieves from origin once

