### PR TITLE
Configuring an S3 Static Websites

### DIFF
--- a/scripts/module_07/configure-s3-website.js
+++ b/scripts/module_07/configure-s3-website.js
@@ -1,18 +1,24 @@
-// Imports
 const AWS = require('aws-sdk')
-
-AWS.config.update({ region: '/* TODO: Add your region */' })
-
-// Declare local variables
+AWS.config.update({ region: 'us-west-2' })
 const s3 = new AWS.S3()
 
 configureS3Site('/* TODO: Add your S3 bucket name */')
 .then(data => console.log(data))
 
 function configureS3Site (bucketName) {
-  // TODO: Create params const object
+  const params = {
+    Bucket: bucketName,
+    WebsiteConfiguration: {
+      IndexDocument: {
+        Suffix: 'index.html'
+      }
+    }
+  }
 
   return new Promise((resolve, reject) => {
-    // Call putBucketWebsite
+    s3.putBucketWebsite(params, (err, data) => {
+      if (err) reject(err)
+      else resolve(data)
+    })
   })
 }


### PR DESCRIPTION

The Science Behind S3 Static Website Hosting
--
S3 Static Websites
Configure an S3 bucket to behave like a website.
S3 Static Websites is letting you configure some static behavior to occur
when directory is referenced in the URL. with S3 static hosting you configure
what the name of your index file will be and what the name of your error file.
The defaults are index.html and error.html
Then you can place these files in any directory in your S3 bucket and
they will be returned when that path is navigated to.

