### PR TITLE
Creating an SQS Queue

### DIFF
--- a/scripts/module_08/create-sqs-queue.js
+++ b/scripts/module_08/create-sqs-queue.js
@@ -1,17 +1,22 @@
-// Imports
 const AWS = require('aws-sdk')
+AWS.config.update({ region: 'us-east-1' })
 
-AWS.config.update({ region: '/* TODO: Add your region */' })
-
-// Declare local variables
-// TODO: Create sqs object
+const sqs = new AWS.SQS()
 const queueName = 'hamster-race-results'
 
 createQueue(queueName)
 .then(data => console.log(data))
 
 function createQueue (queueName) {
-  // TODO: Create params const for creating queue
+  const params = {
+    QueueName: queueName,
+    Attributes: {
+      DelaySeconds: '0',
+      MessageRetentionPeriod: '345600',
+      VisibilityTimeout: '30',
+      ReceiveMessageWaitTimeSeconds: '0'
+    }
+  }
 
   return new Promise((resolve, reject) => {
     sqs.createQueue(params, (err, data) => {


### PR DESCRIPTION

Understanding SQS Polling and the Message Lifecycle
--
Delay Seconds
Amount of time to delay the visibility of an incoming message.
This delay seconds attribute will delay the visibility of a message in the queue
for a given number of seconds when the message initially arrives in the queue.
Once the message is visible and a consumer reads it another attribute comes into
play, the visibility timeout.
Visibility Timeout
Amount of time to make the message invisible after it has been read by a consumer.
Once a message is read it is considered in flight, this means the message is still in the queue,
but it's not visible to consumers. Until the visibility timeout runs its course, the message will
stay in the queue and be invisible. If the visibility timeout runs out, then the message becomes
visible to consumers again and they can then read it which starts the visibility timer all over
again for the message.
 
Default delay seconds and visibility timeout are set on
the queue, but a consumer can override them
Another default value you can set on your queue is
how long consumers should wait when they're
polling for messages. This can be set up to 20 sec.
This is called long polling.

