### PR TITLE
Implementing a Kinesis Stream Consumer

### DIFF
--- a/scripts/module_08/create-kinesis-consumer.js
+++ b/scripts/module_08/create-kinesis-consumer.js
@@ -1,13 +1,11 @@
-// Imports
 const AWS = require('aws-sdk')
 const helpers = require('./helpers')
 
-AWS.config.update({ region: '/* TODO: Add your region */' })
+AWS.config.update({ region: 'arn:aws:kinesis:us-east-1:180732999116:stream/hamster-race-result' })
 
-// Declare local variables
 const lambda = new AWS.Lambda()
 const functionName = 'hamster-kinesis-stream-consumer'
-const kinesisArn = '/* TODO: Add your kinesis ARN */'
+const kinesisArn = ''
 let roleArn
 
 helpers.createLambdaKinesisRole()
@@ -44,7 +42,12 @@ function createLambda (roleArn, lambdaName, zippedCode) {
 }
 
 function createTrigger (kinesisArn, lambdaName) {
-  // TODO: Create params const for trigger
+   const params = {
+     EventSourceArn: kinesisArn,
+     FunctionName: lambdaName,
+     StartingPosition: 'LATEST',
+     BatchSize: 100
+   }
 
   return new Promise((resolve, reject) => {
     lambda.createEventSourceMapping(params, (err, data) => {

--- a/scripts/module_08/lambda-kinesis-consumer/index.js
+++ b/scripts/module_08/lambda-kinesis-consumer/index.js
@@ -2,7 +2,7 @@ const AWS = require('aws-sdk')
 
 const RACES_TABLE = 'races'
 
-AWS.config.update({ region: '/* TODO: Add your region */' })
+AWS.config.update({ region: 'us-east-1' })
 
 const client = new AWS.DynamoDB.DocumentClient()
 


### PR DESCRIPTION

Implementing a Kinesis Stream Consumer
--
AWS Lambda functions can use Kinesis Streams as a trigger
Kinesis Streams Limit
1MB hard limit on size of data blobs
CloudFront Limit
1000 PUT operations per shard
SQS provides a more distributed and decoupled form of sending messages.
Kenesis provides real-time and high-throughput streams.

